### PR TITLE
initiate rotko lvl6

### DIFF
--- a/members.json
+++ b/members.json
@@ -402,7 +402,7 @@
         "6": "",
         "7": ""
       },
-      "services_address": "160.22.181.181",
+      "services_address": "160.22.181.81",
       "endpoints": {
         "westend": "wss://rpc.rotko.net/westend",
         "kusama": "wss://rpc.rotko.net/kusama",

--- a/members_professional.json
+++ b/members_professional.json
@@ -72,12 +72,13 @@
   },
   "Rotko Networks": {
     "Details": {"Name": "Rotko Networks", "Website": "https://rotko.net", "Logo": "https://raw.githubusercontent.com/ibp-network/config/main/logos/rotko.png"},
-    "Membership": {"MemberLevel": 5, "Joined": 1678165200, "LastRankup": 1707184705},
-    "Service": {"Active": 1, "ServiceIPv4": "160.22.181.181", "ServiceIPv6": "2401:a860:1181::", "MonitorUrl": "https://ibp.rotko.net"}, 
+    "Membership": {"MemberLevel": 6, "Joined": 1678165200, "LastRankup": 1754501534},
+    "Service": {"Active": 1, "ServiceIPv4": "160.22.181.81", "ServiceIPv6": "2401:a860:1081::", "MonitorUrl": "https://status.rotko.net"}, 
     "ServiceAssignments": {
       "Paseo": ["Paseo", "Asset-Hub-Paseo", "PAsset-Hub-Paseo", "ETH-PAsset-Hub-Paseo", "Bridge-Hub-Paseo", "Coretime-Paseo", "People-Paseo"], 
       "Kusama": ["Kusama", "Asset-Hub-Kusama", "ETH-Asset-Hub-Kusama", "Bridge-Hub-Kusama", "Coretime-Kusama", "Encointer-Kusama", "People-Kusama"],
-      "Polkadot": ["Polkadot", "Asset-Hub-Polkadot", "Bridge-Hub-Polkadot", "Collectives-Polkadot", "Coretime-Polkadot", "People-Polkadot"]
+      "Polkadot": ["Polkadot", "Asset-Hub-Polkadot", "Bridge-Hub-Polkadot", "Collectives-Polkadot", "Coretime-Polkadot", "People-Polkadot"],
+      "Level6": ["Acala", "Ajuna", "Bifrost-Polkadot", "Hydration", "Nexus", "Kilt", "Moonbeam", "Mythos", "Polimec", "Unique", "Xcavate"]
     },
     "Location": {"Region": "Asia", "Latitude": 13.7563, "Longitude": 100.5018}
   },

--- a/members_professional.json
+++ b/members_professional.json
@@ -73,7 +73,7 @@
   "Rotko Networks": {
     "Details": {"Name": "Rotko Networks", "Website": "https://rotko.net", "Logo": "https://raw.githubusercontent.com/ibp-network/config/main/logos/rotko.png"},
     "Membership": {"MemberLevel": 5, "Joined": 1678165200, "LastRankup": 1707184705},
-    "Service": {"Active": 1, "ServiceIPv4": "160.22.181.181", "ServiceIPv6": "", "MonitorUrl": "https://ibp.rotko.net"}, 
+    "Service": {"Active": 1, "ServiceIPv4": "160.22.181.181", "ServiceIPv6": "2401:a860:1181::", "MonitorUrl": "https://ibp.rotko.net"}, 
     "ServiceAssignments": {
       "Paseo": ["Paseo", "Asset-Hub-Paseo", "PAsset-Hub-Paseo", "ETH-PAsset-Hub-Paseo", "Bridge-Hub-Paseo", "Coretime-Paseo", "People-Paseo"], 
       "Kusama": ["Kusama", "Asset-Hub-Kusama", "ETH-Asset-Hub-Kusama", "Bridge-Hub-Kusama", "Coretime-Kusama", "Encointer-Kusama", "People-Kusama"],


### PR DESCRIPTION
we replaced vrrp loadbalancer with anycast setup. rpc services now highly available across 3 nodes with automatic failover.

## what we built
- **3 haproxy nodes** (bkk06/07/08) all announce same service ip via bgp
- **anycast routing**: traffic automatically routes to closest/healthiest node
- **bgp integration**: nodes peer with route reflectors (bkk00/bkk20) for full mesh routing
- **instant failover**: when node fails, bgp withdraws route and traffic reroutes

## new service addresses
- **ipv4**: `160.22.181.81` (replaces old vrrp ip)
- **ipv6**: `2401:a860:1081::`
- **endpoints**: all `*.rotko.net` domains point to anycast ips

## how redundancy works
1. each haproxy binds to anycast ip on loopback interface
2. bird announces anycast routes to network via bgp  
3. route reflectors distribute to all nodes
4. traffic flows to nearest announcing node
5. if node goes down, bgp automatically withdraws its announcement
6. remaining nodes handle traffic seamlessly

cfg for curious to be seen at 
https://github.com/rotkonetworks/networking
lvl6 nodes monitoring at
https://status.rotko.net

EDIT: still a draft until application form is accepted